### PR TITLE
Add suport for JUnit 5 tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>edu.illinois.cs</groupId>
     <artifactId>idflakies</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
 
     <name>iDFlakies</name>
     <description>A tool for detecting flaky tests</description>
@@ -68,7 +66,17 @@
         <dependency>
             <groupId>edu.illinois.cs</groupId>
             <artifactId>testrunner-maven-plugin</artifactId>
-            <version>1.0</version>
+            <!-- TODO: update dependency -->
+            <version>1.2-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Need below dependency to compile after upgrading
+             the testrunner-maven-plugin, don't know why -->
+        <!-- https://github.com/ReedOei/dt-fixing-tools -->
+        <dependency>
+            <groupId>edu.illinois.cs</groupId>
+            <artifactId>dt-fixing-tools</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/edu/illinois/cs/dt/tools/analysis/Analysis.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/analysis/Analysis.java
@@ -493,8 +493,7 @@ public class Analysis extends StandardMain {
 
         return new TestRunResult("the id is unimportant and should never be referenced",
                 originalOrder,
-                testOutcomes,
-                new HashMap<>());
+                testOutcomes);
     }
 
     private void insertDetectionRound(final String name, final String roundType,

--- a/src/main/java/edu/illinois/cs/dt/tools/detection/RebuildDetectionRounds.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/RebuildDetectionRounds.java
@@ -97,7 +97,7 @@ public class RebuildDetectionRounds extends StandardMain {
             testResults.put(testName, new TestResult(testName, Result.PASS, 0, new StackTraceElement[0]));
         }
 
-        return new TestRunResult("id doesnt matter", originalOrder, testResults, new HashMap<>());
+        return new TestRunResult("id doesnt matter", originalOrder, testResults);
     }
 
     private Set<String> rebuildRounds(final List<String> originalOrder,


### PR DESCRIPTION
The testrunner plugin now can return two runners, one for JUnit 4
and one for JUnit 5.

But there is a limitation: for simplicity, we support J4-only or
J5-only project, which means that if two runners are returned, an
exception will be throw.